### PR TITLE
Prevent plugin from overriding non-spacer layers.

### DIFF
--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -30,7 +30,7 @@ class Resizer {
           layer.resetSizeToMaster()
         }
 
-        if (this._renameSymbol) {
+        if (this._renameSymbol && layer.name().indexOf(this._spacerName) > -1)  {
           layer.name = layer.symbolMaster().name()
         }
       }


### PR DESCRIPTION
Great plugin, team! It's been a great addition to my sketch workflow so far.

The rest of my team cannot utilize it, however, as it destroys our symbol overrides. It would be nice if it only changed spacing symbols. This change prevents the plugin from doing that. Only layers declared in the plugin preferences get changed.